### PR TITLE
Add scroll view to login/signup screens to prevent overflow

### DIFF
--- a/lib/screens/Login/components/body.dart
+++ b/lib/screens/Login/components/body.dart
@@ -15,42 +15,44 @@ class Body extends StatelessWidget {
   @override
   Widget build(BuildContext context) {
     return Background(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          const Text(
-            "LOGIN",
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const Image(
-            image: AssetImage(
-              'assets/images/login.png',
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              "LOGIN",
+              style: TextStyle(fontWeight: FontWeight.bold),
             ),
-            fit: BoxFit.cover,
-          ),
-          RoundedInputField(
-            hintText: "Your email",
-            onChanged: (value) {},
-          ),
-          RoundedPasswordField(
-            onChanged: (value) {},
-          ),
-          const SizedBox(height: 10),
-          RoundedButton(text: "LOG IN", press: () {}),
-          const SizedBox(height: 10),
-          AlreadyHaveAccountCheck(
-            press: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) {
-                    return const SignUpScreen();
-                  },
-                ),
-              );
-            },
-          )
-        ],
+            const Image(
+              image: AssetImage(
+                'assets/images/login.png',
+              ),
+              fit: BoxFit.cover,
+            ),
+            RoundedInputField(
+              hintText: "Your email",
+              onChanged: (value) {},
+            ),
+            RoundedPasswordField(
+              onChanged: (value) {},
+            ),
+            const SizedBox(height: 10),
+            RoundedButton(text: "LOG IN", press: () {}),
+            const SizedBox(height: 10),
+            AlreadyHaveAccountCheck(
+              press: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(
+                    builder: (context) {
+                      return const SignUpScreen();
+                    },
+                  ),
+                );
+              },
+            )
+          ],
+        ),
       ),
     );
   }

--- a/lib/screens/Signup/components/body.dart
+++ b/lib/screens/Signup/components/body.dart
@@ -8,54 +8,52 @@ import 'package:flutter/material.dart';
 import '../../../components/already_have_account_check.dart';
 
 class Body extends StatelessWidget {
-  const Body({
-    Key? key
-  }) : super(key: key);
+  const Body({Key? key}) : super(key: key);
 
   @override
   Widget build(BuildContext context) {
     return Background(
-      child: Column(
-        mainAxisAlignment: MainAxisAlignment.center,
-        children: <Widget>[
-          const Text(
-            "SIGN UP",
-            style: TextStyle(fontWeight: FontWeight.bold),
-          ),
-          const Image(
-            image: AssetImage(
-              'assets/images/signup.png',
+      child: SingleChildScrollView(
+        child: Column(
+          mainAxisAlignment: MainAxisAlignment.center,
+          children: <Widget>[
+            const Text(
+              "SIGN UP",
+              style: TextStyle(fontWeight: FontWeight.bold),
             ),
-            fit: BoxFit.cover,
-          ),
-          RoundedInputField(
-            hintText: "Full Name",
-            onChanged: (value) {},
-          ),
-          RoundedInputField(
-            hintText: "Your email",
-            onChanged: (value) {},
-          ),
-          RoundedPasswordField(
+            const Image(
+              image: AssetImage(
+                'assets/images/signup.png',
+              ),
+              fit: BoxFit.cover,
+            ),
+            RoundedInputField(
+              hintText: "Full Name",
               onChanged: (value) {},
-          ),
-          RoundedButton(
+            ),
+            RoundedInputField(
+              hintText: "Your email",
+              onChanged: (value) {},
+            ),
+            RoundedPasswordField(
+              onChanged: (value) {},
+            ),
+            RoundedButton(
               text: "SIGN UP",
               press: () {},
-          ),
-          AlreadyHaveAccountCheck(
-            login: false,
-            press: () {
-              Navigator.push(
-                context,
-                MaterialPageRoute(
-                  builder: (context) => const LoginScreen()),
-              );
-            },
-          ),
-      ],
-    ),
+            ),
+            AlreadyHaveAccountCheck(
+              login: false,
+              press: () {
+                Navigator.push(
+                  context,
+                  MaterialPageRoute(builder: (context) => const LoginScreen()),
+                );
+              },
+            ),
+          ],
+        ),
+      ),
     );
   }
 }
-


### PR DESCRIPTION
**Notes**
- The login/signup views were throwing errors because opening the keyboard caused an overflow on the screen
- Wrapped the views with a `SingleChildScrollView()` to fix this