### PR TITLE
Add locations screen

### DIFF
--- a/android/app/build.gradle
+++ b/android/app/build.gradle
@@ -44,7 +44,7 @@ android {
 
     defaultConfig {
         applicationId "com.csc4360.boba_time"
-        minSdkVersion 19
+        minSdkVersion 20
         targetSdkVersion 29
         versionCode flutterVersionCode.toInteger()
         versionName flutterVersionName

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -30,5 +30,8 @@
         <meta-data
             android:name="flutterEmbedding"
             android:value="2" />
+
+        <meta-data android:name="com.google.android.geo.API_KEY"
+               android:value="AIzaSyBrr2-Y_obIgBYlokELQIc6tjXEFIwqUQI"/>
     </application>
 </manifest>

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -8,6 +8,7 @@ import Flutter
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
     GeneratedPluginRegistrant.register(with: self)
+    GMSServices.provideAPIKey("AIzaSyBrr2-Y_obIgBYlokELQIc6tjXEFIwqUQI")
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }
 }

--- a/lib/components/already_have_account_check.dart
+++ b/lib/components/already_have_account_check.dart
@@ -1,8 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:boba_time/constants.dart';
 
-import '../constants.dart';
-
 class AlreadyHaveAccountCheck extends StatelessWidget {
   final bool login;
   final VoidCallback press;

--- a/lib/components/components.dart
+++ b/lib/components/components.dart
@@ -1,0 +1,5 @@
+export 'already_have_account_check.dart';
+export 'round_button.dart';
+export 'round_input_field.dart';
+export 'round_password_field.dart';
+export 'text_field_container.dart';

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:animated_splash_screen/animated_splash_screen.dart';
-import 'package:boba_time/screens/landing_screen.dart';
+import 'package:boba_time/screens/screens.dart';
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:page_transition/page_transition.dart';

--- a/lib/model/model.dart
+++ b/lib/model/model.dart
@@ -1,0 +1,2 @@
+export 'menu_item_model.dart';
+export 'user_model.dart';

--- a/lib/screens/Location/location_screen.dart
+++ b/lib/screens/Location/location_screen.dart
@@ -1,0 +1,55 @@
+import 'package:flutter/material.dart';
+import 'package:google_maps_flutter/google_maps_flutter.dart';
+
+class LocationScreen extends StatefulWidget {
+  const LocationScreen({Key? key}) : super(key: key);
+
+  @override
+  State<LocationScreen> createState() => _LocationScreenState();
+}
+
+class _LocationScreenState extends State<LocationScreen> {
+  late GoogleMapController mapController;
+
+  final List<Marker> _markers = <Marker>[];
+
+  final LatLng _center = const LatLng(33.7490, -84.3880);
+
+  void _onMapCreated(GoogleMapController controller) {
+    mapController = controller;
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    _markers.add(
+      const Marker(
+        markerId: MarkerId('GSU'),
+        position: LatLng(33.753746, -84.386330),
+        infoWindow: InfoWindow(title: 'boba time @ GSU'),
+      ),
+    );
+
+    return MaterialApp(
+      home: Scaffold(
+        appBar: AppBar(
+          title: const Text('Locations'),
+          backgroundColor: const Color(0xffffd8cf),
+          leading: IconButton(
+            icon: const Icon(Icons.arrow_back),
+            onPressed: () {
+              Navigator.pop(context);
+            },
+          ),
+        ),
+        body: GoogleMap(
+          onMapCreated: _onMapCreated,
+          initialCameraPosition: CameraPosition(
+            target: _center,
+            zoom: 11.0,
+          ),
+          markers: Set<Marker>.of(_markers),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/screens/Login/components/body.dart
+++ b/lib/screens/Login/components/body.dart
@@ -1,15 +1,10 @@
-import 'package:boba_time/components/round_button.dart';
-import 'package:boba_time/screens/Signup/signup_screen.dart';
-import 'package:boba_time/screens/home_screen.dart';
+import 'package:boba_time/screens/screens.dart';
 import 'package:email_validator/email_validator.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:boba_time/screens/Login/components/background.dart';
 import 'package:fluttertoast/fluttertoast.dart';
-
-import '../../../components/already_have_account_check.dart';
-import '../../../components/round_input_field.dart';
-import '../../../components/round_password_field.dart';
+import 'package:boba_time/components/components.dart';
 
 class Body extends StatelessWidget {
   Body({

--- a/lib/screens/Menu/components/menu_item.dart
+++ b/lib/screens/Menu/components/menu_item.dart
@@ -1,7 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:cached_network_image/cached_network_image.dart';
 
-import '../../../model/menu_item_model.dart';
+import '../../../model/model.dart';
 
 class MenuItem extends StatelessWidget {
   final MenuItemModel menuItem;

--- a/lib/screens/Menu/menu.dart
+++ b/lib/screens/Menu/menu.dart
@@ -1,8 +1,7 @@
 import 'package:boba_time/screens/Menu/components/menu_item.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter/material.dart';
-
-import '../../model/menu_item_model.dart';
+import 'package:boba_time/model/model.dart';
 
 class MenuScreen extends StatefulWidget {
   const MenuScreen({Key? key}) : super(key: key);

--- a/lib/screens/Profile/components/body.dart
+++ b/lib/screens/Profile/components/body.dart
@@ -1,7 +1,5 @@
-import 'package:boba_time/screens/landing_screen.dart';
 import 'package:flutter/material.dart';
-
-import '../../Reward/reward_screen.dart';
+import 'package:boba_time/screens/screens.dart';
 import 'profile_menu.dart';
 import 'profile_pic.dart';
 

--- a/lib/screens/Signup/components/body.dart
+++ b/lib/screens/Signup/components/body.dart
@@ -1,16 +1,12 @@
-import 'package:boba_time/components/round_button.dart';
-import 'package:boba_time/components/round_input_field.dart';
-import 'package:boba_time/components/round_password_field.dart';
-import 'package:boba_time/screens/Login/login_screen.dart';
+import 'package:boba_time/screens/screens.dart';
 import 'package:boba_time/screens/Signup/components/background.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:email_validator/email_validator.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:fluttertoast/fluttertoast.dart';
-
-import '../../../components/already_have_account_check.dart';
-import '../../../model/user_model.dart';
+import 'package:boba_time/components/components.dart';
+import 'package:boba_time/model/model.dart';
 
 class Body extends StatelessWidget {
   Body({Key? key}) : super(key: key);

--- a/lib/screens/home_screen.dart
+++ b/lib/screens/home_screen.dart
@@ -1,13 +1,9 @@
-import 'package:boba_time/screens/Menu/menu.dart';
-import 'package:boba_time/screens/Reward/reward_screen.dart';
-import 'package:boba_time/widgets/app_text.dart';
+import 'package:boba_time/screens/screens.dart';
 import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
-
-import '../model/user_model.dart';
-import '../widgets/navbar.dart';
-import '../widgets/app_text.dart';
+import 'package:boba_time/model/model.dart';
+import 'package:boba_time/widgets/widgets.dart';
 
 class HomeScreen extends StatefulWidget {
   final bool isGuest;
@@ -129,7 +125,16 @@ class _HomeScreenState extends State<HomeScreen> {
                     mainAxisAlignment: MainAxisAlignment.spaceEvenly,
                     children: [
                       InkWell(
-                        onTap: () {},
+                        onTap: () {
+                          Navigator.push(
+                            context,
+                            MaterialPageRoute(
+                              builder: (context) {
+                                return const LocationScreen();
+                              },
+                            ),
+                          );
+                        },
                         child: Column(
                           mainAxisSize: MainAxisSize.min,
                           children: const <Widget>[

--- a/lib/screens/landing_screen.dart
+++ b/lib/screens/landing_screen.dart
@@ -1,8 +1,6 @@
-import 'package:boba_time/screens/home_screen.dart';
 import 'package:flutter/material.dart';
-import 'package:boba_time/screens/Login/login_screen.dart';
-
-import '../widgets/app_buttons.dart';
+import 'package:boba_time/screens/screens.dart';
+import 'package:boba_time/widgets/widgets.dart';
 
 class LandingScreen extends StatelessWidget {
   const LandingScreen({Key? key}) : super(key: key);
@@ -55,7 +53,7 @@ class LandingScreen extends StatelessWidget {
                     child: AppButtons.mainButton(
                       'LOCATIONS',
                       onPressed: () {
-                        _continueAsGuest(context);
+                        _openLocations(context);
                       },
                       buttonColor: const Color(0xff603a22),
                       textColor: Colors.white,
@@ -96,6 +94,15 @@ class LandingScreen extends StatelessWidget {
         builder: (context) => const HomeScreen(
           isGuest: true,
         ),
+      ),
+    );
+  }
+
+  void _openLocations(BuildContext context) {
+    Navigator.push(
+      context,
+      MaterialPageRoute(
+        builder: (context) => const LocationScreen(),
       ),
     );
   }

--- a/lib/screens/screens.dart
+++ b/lib/screens/screens.dart
@@ -1,0 +1,8 @@
+export 'home_screen.dart';
+export 'landing_screen.dart';
+export 'Location/location_screen.dart';
+export 'Login/login_screen.dart';
+export 'Menu/menu.dart';
+export 'Profile/profile_screen.dart';
+export 'Reward/reward_screen.dart';
+export 'Signup/signup_screen.dart';

--- a/lib/widgets/navbar.dart
+++ b/lib/widgets/navbar.dart
@@ -1,9 +1,7 @@
-import 'package:boba_time/screens/landing_screen.dart';
+import 'package:boba_time/screens/screens.dart';
 import 'package:firebase_auth/firebase_auth.dart';
 import 'package:flutter/material.dart';
 import 'package:share_plus/share_plus.dart';
-
-import '../screens/Profile/profile_screen.dart';
 
 class NavBar extends StatelessWidget {
   final String? fullName;

--- a/lib/widgets/widgets.dart
+++ b/lib/widgets/widgets.dart
@@ -1,0 +1,3 @@
+export 'app_buttons.dart';
+export 'app_text.dart';
+export 'navbar.dart';

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -99,6 +99,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "3.0.1"
+  csslib:
+    dependency: transitive
+    description:
+      name: csslib
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.17.1"
   cupertino_icons:
     dependency: "direct main"
     description:
@@ -202,6 +209,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.0.4"
+  flutter_plugin_android_lifecycle:
+    dependency: transitive
+    description:
+      name: flutter_plugin_android_lifecycle
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.5"
   flutter_svg:
     dependency: "direct main"
     description:
@@ -226,6 +240,41 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "8.0.9"
+  google_maps:
+    dependency: transitive
+    description:
+      name: google_maps
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "5.3.0"
+  google_maps_flutter:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.3"
+  google_maps_flutter_platform_interface:
+    dependency: transitive
+    description:
+      name: google_maps_flutter_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.1.5"
+  google_maps_flutter_web:
+    dependency: "direct main"
+    description:
+      name: google_maps_flutter_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.3.2+1"
+  html:
+    dependency: transitive
+    description:
+      name: html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.15.0"
   http:
     dependency: transitive
     description:
@@ -254,6 +303,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.6.3"
+  js_wrapping:
+    dependency: transitive
+    description:
+      name: js_wrapping
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.7.4"
   lints:
     dependency: transitive
     description:
@@ -415,6 +471,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "0.27.3"
+  sanitize_html:
+    dependency: transitive
+    description:
+      name: sanitize_html
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   share_plus:
     dependency: "direct main"
     description:
@@ -497,6 +560,13 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "2.1.0"
+  stream_transform:
+    dependency: transitive
+    description:
+      name: stream_transform
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.0.0"
   string_scanner:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -43,6 +43,8 @@ dependencies:
   fluttertoast: ^8.0.9
   cloud_firestore: ^3.1.13
   cached_network_image: ^3.2.0
+  google_maps_flutter: ^2.1.3
+  google_maps_flutter_web: ^0.3.2+1
 
 dev_dependencies:
   flutter_test:

--- a/web/index.html
+++ b/web/index.html
@@ -26,6 +26,8 @@
   <meta name="apple-mobile-web-app-title" content="boba_time">
   <link rel="apple-touch-icon" href="icons/Icon-192.png">
 
+  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBrr2-Y_obIgBYlokELQIc6tjXEFIwqUQI"></script>
+
   <!-- Favicon -->
   <link rel="icon" type="image/png" href="favicon.png"/>
 


### PR DESCRIPTION
**Notes**
- Added Google maps location screen
  - Since there are no actual boba time locations, added a single location at GSU :)
  - Updated routing to locations screen from landing and home screens' buttons
- Refactored imports to use a single file, for example:
  - all screens are exported in `screens.dart`, so now only a single import is needed for all screens on any file

**Testing**
- `flutter run`
- tested end-to-end flow on the Android emulator 